### PR TITLE
404 Error Handling + exposing more types to consuming apps

### DIFF
--- a/src/ComfyUIWorkflow.ts
+++ b/src/ComfyUIWorkflow.ts
@@ -10,9 +10,9 @@ const deepClone: <T>(obj: T) => T = globalThis.structuredClone
   ? globalThis.structuredClone
   : (x) => JSON.parse(JSON.stringify(x));
 
-type NodeOutput = [string, number];
+export type NodeOutput = [string, number];
 
-type NodeClassInputs = Record<
+export type NodeClassInputs = Record<
   string,
   string | boolean | number | null | undefined | NodeOutput
 >;
@@ -24,11 +24,13 @@ type InputsFormat<T> = {
     : T[K] | NodeOutput;
 };
 
-interface ComfyUINodeClass<INP extends NodeClassInputs = NodeClassInputs> {
+export interface ComfyUINodeClass<
+  INP extends NodeClassInputs = NodeClassInputs,
+> {
   (inputs: INP): NodeOutput[];
 }
 
-type BuiltinNodeClasses = {
+export type BuiltinNodeClasses = {
   [K in keyof Required<ComfyUINodeTypes.NodeTypes>]: Required<
     Required<ComfyUINodeTypes.NodeTypes>[K]
   > extends {
@@ -38,7 +40,7 @@ type BuiltinNodeClasses = {
     : ComfyUINodeClass<NodeClassInputs>;
 };
 
-type InvokeOptions<T> = {
+export type InvokeOptions<T> = {
   resolver?: WorkflowOutputResolver<T>;
   progress?: (p: ComfyUiWsTypes.Messages.Progress) => void;
   polling_ms?: number;

--- a/src/ComfyUIWsClient.ts
+++ b/src/ComfyUIWsClient.ts
@@ -34,6 +34,9 @@ type ComfyUIClientEvents = {
    */
   close: any;
 
+  // network connection errors
+  connection_error: { type: string; message: string };
+
   /**
    * unhandled event message
    */
@@ -345,14 +348,15 @@ export class ComfyUIWsClient {
       // Expose websocket errors as unhandled events
       // Allows for catching 404 and other network errors
       const err = ev as ErrorEvent;
-      this.events.emit("unhandled", {
-        type: "WebSocket Error",
-        data: err.message,
+      const is404Error = err.message?.includes("404");
+
+      this.events.emit("connection_error", {
+        type: "404",
+        message: err.message,
       });
 
       if (this.socket) this.socket.close();
 
-      const is404Error = err.message?.includes("404");
       if (!is404Error && !isReconnect && !opened) {
         this.startPollingQueue();
       }

--- a/src/ComfyUIWsClient.ts
+++ b/src/ComfyUIWsClient.ts
@@ -216,10 +216,17 @@ export class ComfyUIWsClient {
       throw new Error("Client is closed");
     }
     const url = this.apiURL(route);
-    return this.fetch(url, {
+    const res = await this.fetch(url, {
       ...options,
       headers: this.apiHeaders(options),
     });
+
+    // 404 check because fetch doesn't consider a 404 an error
+    if (res.status === 404) {
+      throw new Error(`ComfyUI API Endpoint not found (404): ${url}`);
+    }
+
+    return res;
   }
 
   /**

--- a/src/ComfyUIWsClient.ts
+++ b/src/ComfyUIWsClient.ts
@@ -341,9 +341,19 @@ export class ComfyUIWsClient {
       }
     });
 
-    this.addSocketCallback(this.socket, "error", () => {
+    this.addSocketCallback(this.socket, "error", (ev: Event) => {
+      // Expose websocket errors as unhandled events
+      // Allows for catching 404 and other network errors
+      const err = ev as ErrorEvent;
+      this.events.emit("unhandled", {
+        type: "WebSocket Error",
+        data: err.message,
+      });
+
       if (this.socket) this.socket.close();
-      if (!isReconnect && !opened) {
+
+      const is404Error = err.message?.includes("404");
+      if (!is404Error && !isReconnect && !opened) {
         this.startPollingQueue();
       }
     });


### PR DESCRIPTION
- REST: explicitly throw exception on 404 because fetch doesn't consider a 404 an error
- WebSocket: emit 404 errors as new `connection_error` event
- expose more types for consumption by consuming apps

